### PR TITLE
switching get_corresponding_roadway(String) to check using contains

### DIFF
--- a/src/trajdata.jl
+++ b/src/trajdata.jl
@@ -330,7 +330,7 @@ function Base.convert(::Type{Trajdata}, tdraw::NGSIMTrajdata, roadway::Roadway)
     Trajdata(NGSIM_TIMESTEP, frames, states, vehdefs)
 end
 
-get_corresponding_roadway(filename::String) = startswith(filename, "i101") ? ROADWAY_101 : ROADWAY_80
+get_corresponding_roadway(filename::String) = contains(filename, "i101") ? ROADWAY_101 : ROADWAY_80
 
 
 function convert_raw_ngsim_to_trajdatas()


### PR DESCRIPTION
The checked-for value occurs partway through the roadway name.