### PR TITLE
update rename function in ngsim_trajdata.jl file

### DIFF
--- a/src/ngsim_trajdata.jl
+++ b/src/ngsim_trajdata.jl
@@ -34,7 +34,7 @@ mutable struct NGSIMTrajdata
         df = readtable(input_path, separator=' ', header = false)
         col_names = [:id, :frame, :n_frames_in_dataset, :epoch, :local_x, :local_y, :global_x, :global_y, :length, :width, :class, :speed, :acc, :lane, :carind_front, :carind_rear, :dist_headway, :time_headway]
         for (i,name) in enumerate(col_names)
-            rename!(df, Symbol(@sprintf("x%d", i)), name)
+            rename!(df, Symbol(@sprintf("x%d", i))=> name)
         end
 
         df[:global_heading] = fill(NaN, nrow(df))


### PR DESCRIPTION
this change is for the issue of https://github.com/sisl/ngsim_env/issues/13

```sh
julia> convert_raw_ngsim_to_trajdatas()
converting i101_trajectories-0750am-0805am.txt
loading from file: ┌ Warning: readtable is deprecated, use CSV.read from the CSV package instead
│   caller = ip:0x0
└ @ Core :-1
ERROR: MethodError: no method matching rename!(::DataFrames.Index, ::Symbol, ::Symbol)
Closest candidates are:
  rename!(::DataFrames.Index, ::Any) at /home/yang/.julia/packages/DataFrames/yH0f6/src/other/index.jl:49
  rename!(::DataFrames.AbstractDataFrame, ::Any...) at /home/yang/.julia/packages/DataFrames/yH0f6/src/abstractdataframe/abstractdataframe.jl:117
  rename!(::DataFrames.Index, ::Pair{Symbol,Symbol}...) at /home/yang/.julia/packages/DataFrames/yH0f6/src/other/index.jl:60
Stacktrace:
 [1] rename!(::DataFrames.DataFrame, ::Symbol, ::Symbol) at /home/yang/.julia/packages/DataFrames/yH0f6/src/abstractdataframe/abstractdataframe.jl:117
 [2] NGSIMTrajdata(::String) at /home/yang/.julia/packages/NGSIM/OPF1x/src/ngsim_trajdata.jl:37
 [3] #load_ngsim_trajdata#35(::Bool, ::Function, ::String) at /home/yang/.julia/packages/NGSIM/OPF1x/src/trajdata.jl:146
 [4] load_ngsim_trajdata at /home/yang/.julia/packages/NGSIM/OPF1x/src/trajdata.jl:145 [inlined]
 [5] convert_raw_ngsim_to_trajdatas() at /home/yang/.julia/packages/NGSIM/OPF1x/src/trajdata.jl:200
 [6] top-level scope at none:0


```

According to https://en.wikibooks.org/wiki/Introducing_Julia/DataFrames#Adding,_deleting,_and_renaming_columns